### PR TITLE
Set user agent in MirrorClient init

### DIFF
--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -4,11 +4,19 @@ import MirrorCoreSDK.EMSConfig
 public class MirrorClient: NSObject, ConnectivityObserver {
 
     @objc
-    public init(appID: String = "", appToken: String = "") {
+  public override init() {
         super.init()
-      
-        EMSConfig.setupAppID(appID, andAppToken: appToken)
         connectivityService.registerObserver(self)
+    }
+  
+    @objc
+    public convenience init?(appID: String, appToken: String) {
+        guard appID != "", appToken != "" else {
+            return nil
+        }
+      
+        self.init()
+        EMSConfig.setupAppID(appID, andAppToken: appToken)
     }
 
     @objc

--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -10,11 +10,7 @@ public class MirrorClient: NSObject, ConnectivityObserver {
     }
   
     @objc
-    public convenience init?(appID: String, appToken: String) {
-        guard appID != "", appToken != "" else {
-            return nil
-        }
-      
+    public convenience init(appID: String, appToken: String) {
         self.init()
         EMSConfig.setupAppID(appID, andAppToken: appToken)
     }

--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -1,10 +1,13 @@
+import MirrorCoreSDK.EMSConfig
+
 @objc
 public class MirrorClient: NSObject, ConnectivityObserver {
 
     @objc
-    public override init() {
+    public override init(appID: String = "", appToken: String = "") {
         super.init()
-
+      
+        EMSConfig.setupAppID(appID, andAppToken: appToken)
         connectivityService.registerObserver(self)
     }
 

--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -9,6 +9,16 @@ public class MirrorClient: NSObject, ConnectivityObserver {
         connectivityService.registerObserver(self)
     }
   
+    /**
+       Initialize with an appID and appToken from your Estimote Cloud App for authorization.
+   
+       - parameters:
+         - appID: The Estimote Cloud App ID. Can not be empty.
+         - appToken: The Estimote Cloud App Token. Can not be empty.
+   
+       - returns:
+       A newly created MirrorClient.
+     */
     @objc
     public convenience init(appID: String, appToken: String) {
         self.init()

--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -4,7 +4,7 @@ import MirrorCoreSDK.EMSConfig
 public class MirrorClient: NSObject, ConnectivityObserver {
 
     @objc
-    public override init(appID: String = "", appToken: String = "") {
+    public init(appID: String = "", appToken: String = "") {
         super.init()
       
         EMSConfig.setupAppID(appID, andAppToken: appToken)


### PR DESCRIPTION
Required for cloud request analytics and the Mirror health check.